### PR TITLE
update resource image selector

### DIFF
--- a/manual_test.rb
+++ b/manual_test.rb
@@ -3,9 +3,10 @@ require_relative 'scraper'
 item = {
   Constants::KEYS[:id] => '201900001',
   'item_published_at' => '2019-02-04 12:00:00',
-  Constants::KEYS[:url] => 'https://www.zendesk.com.mx/support/webinar/whats-new-product-updates-dec-2018-amer',
+  Constants::KEYS[:url] => 'https://www.zendesk.es/resources/5-biggest-gaps-customer-service-midsize-companies',
   'post_status' => 'publish',
-  Constants::KEYS[:type] => 'webinar',
+  Constants::KEYS[:type] => 'resource',
+  'item_tags' => []
 }
 
 item = Scraper.scrape_post(item)

--- a/scraper.rb
+++ b/scraper.rb
@@ -122,7 +122,7 @@ module Scraper
       when 'resource'
         postmeta[:title] = post.css('.blog-header h1')
         postmeta[:content] = post.css('.resource-body-teaser')
-        postmeta[:image] = post.css('#main-image')
+        postmeta[:image] = post.css('.resource-media.show-small-up img')
         postmeta[:tags] = post.css('.blog-tag')
 
         item['item_published_at'] = Util.cpubdate_to_timestamp(
@@ -220,8 +220,6 @@ module Scraper
         else
           postmeta[:image].attribute('src').value
         end
-
-        item['item_title'] = postmeta[:title].first.text
       end
 
       item['item_tags'] = postmeta[:tags].map do |tag|


### PR DESCRIPTION
This PR updates the selector for resource images.

It also removes an error on line 224 of scraper.rb.

It also updates manual_test.rb for use with Spanish resource post types.

To use it, run `ruby manual_test.rb` - it will output the item object created by `Scraper.scrape_post(item)`